### PR TITLE
[FIX] README steps fails: nothing shown on textarea

### DIFF
--- a/micropython/index.html
+++ b/micropython/index.html
@@ -115,6 +115,7 @@ micropython.qstr_info(1)
 <body>
     <textarea id="output" cols=132></textarea>
     <canvas width="250" height="250" id="canvas">Your browser doesn't support Canvas</canvas>
+    <span id="test"></span>
 </body>
 </html>
 


### PR DESCRIPTION
The file `pythons.js` throws on line 278 when index.html is ran.

Console:
```
Uncaught TypeError: Cannot set property 'textContent' of null
    at VM73 pythons.js:278
```

pythons.js:278-279:
```js
document.getElementById('test').textContent = "THIS IS A TEST BLOCK\n"
document.title="THIS IS A TEST TITLE"
```